### PR TITLE
Set up development environment

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,10 @@
 [nosetests]
-verbosity=1
+verbosity=2
+with-spec=1
+spec-color=1
+with-coverage=1
+cover-erase=1
+cover-package=service
 
 [coverage:report]
 show_missing = True


### PR DESCRIPTION
Added nosetests configuration flags to setup.cfg for better test output with color, coverage, and spec formatting.

This allows running tests with just `nosetests` instead of needing all the command-line flags.
